### PR TITLE
Do not crash on revert of story commit

### DIFF
--- a/lib/slackistrano/messaging/apoex.rb
+++ b/lib/slackistrano/messaging/apoex.rb
@@ -108,7 +108,7 @@ module Slackistrano
         if res = commit.match(/\[([#\d,\s]*)\]\s*(.+)\(#(\d+)\)/)
           res.captures
         else
-          [[], nil, nil]
+          ['', nil, nil]
         end
       end
 

--- a/lib/slackistrano/messaging/apoex.rb
+++ b/lib/slackistrano/messaging/apoex.rb
@@ -78,6 +78,8 @@ module Slackistrano
           github_pr_id, tps, name = parse_merge_commit(commit)
           tps, name, github_pr_id = parse_squash_and_merge_commit(commit) unless github_pr_id
 
+          next unless tps
+
           tps.split(',').map do |tp|
             "#{target_process_entity_link(tp, name)} (#{github_pull_request_link(github_pr_id)})"
           end
@@ -97,19 +99,13 @@ module Slackistrano
       end
 
       def parse_merge_commit(commit)
-        if res = commit.match(/Merge pull request #(\d+) from \S+ (?:\[(#?\w+)\])*\s?(.+)/)
-          res.captures
-        else
-          [nil, [], nil]
-        end
+        res = commit.match(/Merge pull request #(\d+) from \S+ (?:\[(#?\w+)\])*\s?(.+)/)
+        res.captures if res
       end
 
       def parse_squash_and_merge_commit(commit)
-        if res = commit.match(/\[([#\d,\s]*)\]\s*(.+)\(#(\d+)\)/)
-          res.captures
-        else
-          ['', nil, nil]
-        end
+        res = commit.match(/\[([#\d,\s]*)\]\s*(.+)\(#(\d+)\)/)
+        res.captures if res
       end
 
       def target_process_entity_link(entity_id, name)

--- a/lib/slackistrano/messaging/apoex.rb
+++ b/lib/slackistrano/messaging/apoex.rb
@@ -76,7 +76,7 @@ module Slackistrano
         warning 'Slackistrano: Error finding pull requests:'
         warning e.message
         warning e.backtrace.join("\n")
-        ''
+        'Error finding pull requests'
       end
 
       def stories
@@ -94,7 +94,7 @@ module Slackistrano
         warning 'Slackistrano: Error finding stories:'
         warning e.message
         warning e.backtrace.join("\n")
-        ''
+        'Error finding stories'
       end
 
       def story_commits

--- a/lib/slackistrano/messaging/apoex.rb
+++ b/lib/slackistrano/messaging/apoex.rb
@@ -1,6 +1,7 @@
 module Slackistrano
   module Messaging
     class Apoex < Base
+      include Capistrano::Doctor::OutputHelpers
 
       def payload_for_updating
         super
@@ -71,6 +72,11 @@ module Slackistrano
 
           "#{name} #{github_pull_request_link(github_pr_id)}"
         end.join("\n")
+      rescue StandardError => e
+        warning 'Slackistrano: Error finding pull requests:'
+        warning e.message
+        warning e.backtrace.join("\n")
+        ''
       end
 
       def stories
@@ -84,6 +90,11 @@ module Slackistrano
             "#{target_process_entity_link(tp, name)} (#{github_pull_request_link(github_pr_id)})"
           end
         end.join("\n")
+      rescue StandardError => e
+        warning 'Slackistrano: Error finding stories:'
+        warning e.message
+        warning e.backtrace.join("\n")
+        ''
       end
 
       def story_commits

--- a/spec/messaging/apoex_spec.rb
+++ b/spec/messaging/apoex_spec.rb
@@ -65,12 +65,22 @@ describe Slackistrano::Messaging::Apoex do
   end
 
   describe '#stories' do
+    let(:story_commit) { squash_merge_commit }
+
     before do
-      expect(subject).to receive(:story_commits).and_return([squash_merge_commit])
+      expect(subject).to receive(:story_commits).and_return([story_commit])
     end
 
     it 'returns the stories' do
       expect(subject.stories).to eq("<https://apoexab.tpondemand.com/entity/1337|#1337 - The best feature ever > (<https://github.com/apoex/test/pull/12|Github :octocat:>)")
+    end
+
+    context 'when story commit is reverted' do
+      let(:story_commit) { "  Revert \"[#12345] Bad code\"" }
+
+      it 'Ignores the story' do
+        expect(subject.stories).to be_empty
+      end
     end
   end
 end

--- a/spec/messaging/apoex_spec.rb
+++ b/spec/messaging/apoex_spec.rb
@@ -62,6 +62,21 @@ describe Slackistrano::Messaging::Apoex do
     it 'returns the pull requests' do
       expect(subject.pull_requests).to eq("This is a merge commit <https://github.com/apoex/test/pull/447|Github :octocat:>")
     end
+
+    context 'when parser breaks' do
+      let(:error) { StandardError.new 'boom' }
+
+      before do
+        allow(subject).to receive(:parse_merge_commit).and_raise(error)
+      end
+
+      it 'renders error message' do
+        expect($stdout).to receive(:puts).with(/Slackistrano: Error finding pull requests:/)
+        expect($stdout).to receive(:puts).with(/boom/)
+        expect($stdout).to receive(:puts).with(/apoex_spec.rb:/)
+        expect(subject.pull_requests).to be_empty
+      end
+    end
   end
 
   describe '#stories' do
@@ -88,6 +103,21 @@ describe Slackistrano::Messaging::Apoex do
         it 'Ignores the story' do
           expect(subject.stories).to be_empty
         end
+      end
+    end
+
+    context 'when parser breaks' do
+      let(:error) { StandardError.new 'boom' }
+
+      before do
+        allow(subject).to receive(:parse_merge_commit).and_raise(error)
+      end
+
+      it 'renders error message' do
+        expect($stdout).to receive(:puts).with(/Slackistrano: Error finding stories:/)
+        expect($stdout).to receive(:puts).with(/boom/)
+        expect($stdout).to receive(:puts).with(/apoex_spec.rb:/)
+        expect(subject.stories).to be_empty
       end
     end
   end

--- a/spec/messaging/apoex_spec.rb
+++ b/spec/messaging/apoex_spec.rb
@@ -81,6 +81,14 @@ describe Slackistrano::Messaging::Apoex do
       it 'Ignores the story' do
         expect(subject.stories).to be_empty
       end
+
+      context 'when merge commit' do
+        let(:story_commit) { "Merge pull request #1815 from apoex/revert-1794-10934-full-package-item-count Revert \"[#10934] Default the number of picking full package items to 1\"" }
+
+        it 'Ignores the story' do
+          expect(subject.stories).to be_empty
+        end
+      end
     end
   end
 end

--- a/spec/messaging/apoex_spec.rb
+++ b/spec/messaging/apoex_spec.rb
@@ -74,7 +74,7 @@ describe Slackistrano::Messaging::Apoex do
         expect($stdout).to receive(:puts).with(/Slackistrano: Error finding pull requests:/)
         expect($stdout).to receive(:puts).with(/boom/)
         expect($stdout).to receive(:puts).with(/apoex_spec.rb:/)
-        expect(subject.pull_requests).to be_empty
+        expect(subject.pull_requests).to eq('Error finding pull requests')
       end
     end
   end
@@ -117,7 +117,7 @@ describe Slackistrano::Messaging::Apoex do
         expect($stdout).to receive(:puts).with(/Slackistrano: Error finding stories:/)
         expect($stdout).to receive(:puts).with(/boom/)
         expect($stdout).to receive(:puts).with(/apoex_spec.rb:/)
-        expect(subject.stories).to be_empty
+        expect(subject.stories).to eq('Error finding stories')
       end
     end
   end


### PR DESCRIPTION
Om man deployar en revert av en TP-story så fick man tidigare felet: `The deploy has failed with an error: undefined method 'split' for []:Array`.


![screen shot 2018-05-09 at 09 43 19](https://user-images.githubusercontent.com/7113050/39802141-909f8d38-536d-11e8-98ca-5386c2218066.png)

![screen shot 2018-05-09 at 09 43 40](https://user-images.githubusercontent.com/7113050/39802140-908523da-536d-11e8-9bc9-44965018a5ad.png)